### PR TITLE
Wrapper component must be always rendered to static markup

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,12 +37,9 @@ module.exports = function engineFactory (engineOptions) {
                body: componentMarkup,
                props: options
             });
-
-            if (engineOptions.staticMarkup) {
-               markup += React.renderToStaticMarkup(wrapperInstance);
-            } else {
-               markup += React.renderToString(wrapperInstance);
-            }
+   
+            markup += React.renderToStaticMarkup(wrapperInstance);
+            
          } else {
             markup += componentMarkup;
          }


### PR DESCRIPTION
Recently I've met an issue, when some browser extensions are modifying body tag and this lead's to 'Invariant Violation' error. I think it will make sense, to render wrapper component only to static markup (React.renderToStaticMarkup), because it consists only of invisible element's (html, head, body, meta tags).
