### PR TITLE
use babel 6

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ module.exports = function engineFactory (engineOptions) {
    });
 
    if (engineOptions.babel) {
-     require('babel/register')(engineOptions.babel);
+     require('babel-core/register')(engineOptions.babel);
    }
 
    return function renderComponent (filename, options, callback) {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "react-dom": "^0.14.0"
   },
   "dependencies": {
-    "babel": "^4.7.16",
+    "babel-core": "^6.0.0",
     "lodash.defaults": "^3.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Using `.babelrc` with the current setup breaks otherwise.

A new release soon would be great!
