### PR TITLE
Allow components to be ES6 modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,14 @@ module.exports = function engineFactory (engineOptions) {
 
       try {
          var markup = engineOptions.docType;
-         var Component = require(filename);
+         var Component;
+
+         if (require(filename).__esModule) {
+            Component = require(filename).default;
+         } else {
+            Component = require(filename);
+         }
+
          var instance = React.createElement(Component, options);
 
          var componentMarkup;


### PR DESCRIPTION
Hey, I'm pretty new to the node environment but I needed to make this change in order to work with ES6 modules (transpiled by Babel 6).

When I require an ES6 module that has been exported via `export default MyComponent`, it looks like this when i `require()` it:

``` javascript
{ __esModule: true, default: [ Function ] }
```

From what I could gather, there's no easy way around this problem.
