### PR TITLE
patch all component Require statements to support both ES6 import/exp…

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,22 +17,25 @@ module.exports = function engineFactory (engineOptions) {
      require('babel-core/register')(engineOptions.babel);
    }
 
+   function requireComponent(_path_){
+      return require(_path_) ? require(_path_).default ? require(_path_).default : require(_path_) : require(_path_);
+   }
+
    return function renderComponent (filename, options, callback) {
       options = options || {};
 
       try {
          var markup = engineOptions.docType;
-         var Component;
-
-         if (require(filename).__esModule) {
-            Component = require(filename).default;
-         } else {
-            Component = require(filename);
-         }
-
-         var instance = React.createElement(Component, options);
+         /** 
+            Depending on whether one is using ES6 import/export style modules, 
+            or Node's require/exports style Modules, we need to specify how
+            we should reference the component from the required file
+         */
+         var ReactComponent = requireComponent(filename);
+         var instance = React.createElement( ReactComponent, options);
 
          var componentMarkup;
+
          if (engineOptions.staticMarkup) {
             componentMarkup = ReactDOMServer.renderToStaticMarkup(instance);
          } else {
@@ -40,7 +43,7 @@ module.exports = function engineFactory (engineOptions) {
          }
 
          if (engineOptions.wrapper) {
-            var Wrapper = require(path.join(this.root, engineOptions.wrapper));
+            var Wrapper = requireComponent(path.join(this.root, engineOptions.wrapper));
             var wrapperInstance = React.createElement(Wrapper, {
                body: componentMarkup,
                props: options


### PR DESCRIPTION
…ort and Node's native require/exports semantics.

After running through some more use cases, I found that the Wrapper component, is subject to the same issues with import/export vs require/exports semantics. 

I broke out the logic to handle this into a function, and patched the code so it uses this new function where needed.
